### PR TITLE
Added missing libraries and fixed missing parenthesis in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,3 +13,4 @@ setup(name='NLradar',
       author="Bram van 't Veen",
       packages=[],
       install_requires=['numpy','pyproj','pyshp','opencv-python','pillow','imageio','pyqt5','scipy','requests','gpxpy','netcdf4==1.6','pyopengl','matplotlib','numpy-bufr @ git+https://github.com/Bram94/numpy_bufr.git','xmltodict','boto3','pytz','av','tensorflow==2.10']
+	  )

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(name='NLradar',
       description='',
       author="Bram van 't Veen",
       packages=[],
-      install_requires=['numpy','pyproj','pyshp','opencv-python','pillow','imageio','pyqt5','scipy','requests','gpxpy','netcdf4==1.6','pyopengl','matplotlib','numpy-bufr @ git+https://github.com/Bram94/numpy_bufr.git','xmltodict','boto3','pytz','av','tensorflow==2.10']
+      install_requires=['numpy','pyproj','pyshp','opencv-python','pillow','imageio','pyqt5','scipy','requests','gpxpy','netcdf4==1.6','pyopengl','matplotlib','numpy-bufr @ git+https://github.com/Bram94/numpy_bufr.git','xmltodict','boto3','pytz','av','tensorflow==2.10','pyperclip','Unidecode']
 	  )


### PR DESCRIPTION
A parenthesis was missing in setup.py which prevented the installation of NLradar.
The libraries pyperclip and Unidecode were missing too, so i added them in setup.py too.